### PR TITLE
The 'top' CSS property should not be set by this directive!

### DIFF
--- a/src/ng-stickyfill.js
+++ b/src/ng-stickyfill.js
@@ -5,8 +5,7 @@ angular.module('stickyfill', [])
       link: function(scope, element) {
         element.css({
           position: '-webkit-sticky',
-          position: 'sticky',
-          top: 0
+          position: 'sticky'
         });
         Stickyfill.add(element[0]);
       }


### PR DESCRIPTION
See the test page: 
http://wilddeer.github.io/stickyfill/test/

Setting 'top' can be done inline, in the CSS / SCSS, and can be a number, or can even be 'Auto' (which negates the effect of the sticky property)
